### PR TITLE
update webos_cli_tv.zip to version 1.11.0 (2021-03-03)

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -17,4 +17,4 @@ assert() {
 
 assert "$(cmd tizen version)" "Tizen CLI 2.5.21"
 assert "$(cmd sdb version)" "Smart Development Bridge version 4.2.12"
-assert "$(cmd ares-setup-device --version)" "Version: 1.10.4-j1703-k"
+assert "$(cmd ares-setup-device --version)" "Version: 1.11.0-j31-k"


### PR DESCRIPTION
Update `webos_cli_tv.zip` file to Version 1.11.0 (2021-03-03) to support more commands and fix issues.